### PR TITLE
Elaborate method used in NormalQuantilePlot

### DIFF
--- a/en/modules/ROOT/pages/commands/NormalQuantilePlot.adoc
+++ b/en/modules/ROOT/pages/commands/NormalQuantilePlot.adoc
@@ -5,4 +5,4 @@ ifdef::env-github[:imagesdir: /en/modules/ROOT/assets/images]
 NormalQuantilePlot( <List of Raw Data> )::
   Creates a normal quantile plot from the given list of data and draws a line through the points showing the ideal plot
   for exactly normal data. Points are formed by plotting data values on the x axis against their expected normal score
-  (Z-score) on the y axis.
+  (Z-score) on the y axis. More precisely the y-values are computed using Filliben's estimate.


### PR DESCRIPTION
Make the method used to compute the y-values explicit. There are several methods in the litterature.
And the choice made by Geogebra is an unsual one. Most programs (NSpire, R etc) uses the method suggested by Blom. Geogebra has chosen to use Filliben's estimate.