### PR TITLE
Update PerpendicularPlane.adoc

### DIFF
--- a/ja/modules/ROOT/pages/commands/PerpendicularPlane.adoc
+++ b/ja/modules/ROOT/pages/commands/PerpendicularPlane.adoc
@@ -1,5 +1,5 @@
 = PerpendicularPlane コマンド
-:page-en:commands/PerpendicularPlane
+:page-en: commands/PerpendicularPlane
 ifdef::env-github[:imagesdir: /ja/modules/ROOT/assets/images]
 
 PerpendicularPlane( <点>, <直線> )::


### PR DESCRIPTION
In the manual, there is a space between the colon and ‘commands’ as in ‘:page-en: commands/PerpendicularPlane’. Is this correct?