### PR TITLE
alt+shift shortcuts

### DIFF
--- a/en/modules/ROOT/pages/Keyboard_Shortcuts.adoc
+++ b/en/modules/ROOT/pages/Keyboard_Shortcuts.adoc
@@ -137,6 +137,8 @@ Worksheet
 
 |0 |[.kcode]#Alt# + [.kcode]#0# |X |X |X | |to the power of 0
 
+|0 |[.kcode]#Alt# + [.kcode]#Shift# + [.kcode]#0# |X |X | X| X| } (right curly bracket)
+
 |1 |[.kcode]#Ctrl# + [.kcode]#1# |X |X |X |[.kcode]#Cmd# + [.kcode]#1# |Standard font size, line thickness, and point
 size
 
@@ -155,21 +157,35 @@ size
 image:16px-Menu_view_graphics2.svg.png[Menu view graphics2.svg,width=16,height=16] xref:/Graphics_View.adoc[Graphics
 View] 2
 
+|2 |[.kcode]#Alt# + [.kcode]#Shift# + [.kcode]#2# |X |X | X| X| € (euro symbol)
+
 |3 |[.kcode]#Ctrl# + [.kcode]#3# |X |X |X |[.kcode]#Cmd# + [.kcode]#3# |Black/white mode
 
 |3 |[.kcode]#Alt# + [.kcode]#3# |X |X |X | |to the power of 3
 
+|3 |[.kcode]#Alt# + [.kcode]#Shift# + [.kcode]#3# |X |X | X| X| « (much less than)
+
 |4 |[.kcode]#Alt# + [.kcode]#4# |X |X |X | |to the power of 4
 
+| 4 |[.kcode]#Alt# + [.kcode]#Shift# + [.kcode]#4#  |X |X | X| X| » (much greater than)
+
 |5 |[.kcode]#Alt# + [.kcode]#5# |X |X | | |to the power of 5
+
+|5 |[.kcode]#Alt# + [.kcode]#Shift# + [.kcode]#5# |X |X | X| X| £  (pound symbol)
 
 |6 |[.kcode]#Alt# + [.kcode]#6# |X |X | | |to the power of 6
 
 |7 |[.kcode]#Alt# + [.kcode]#7# |X |X | | |to the power of 7
 
+|7 |[.kcode]#Alt# + [.kcode]#Shift# + [.kcode]#7# |X |X | X| X| \ (backslash)
+
 |8 |[.kcode]#Alt# + [.kcode]#8# |X |X | | |to the power of 8
 
+|8 |[.kcode]#Alt# + [.kcode]#Shift# + [.kcode]#8# |X |X | X| X| ⊗ (tensor product)
+
 |9 |[.kcode]#Alt# + [.kcode]#9# |X |X | | |to the power of 9
+
+|9 |[.kcode]#Alt# + [.kcode]#Shift# + [.kcode]#9#  |X |X | X| X| { (left curly bracket)
 
 |- |[.kcode]#-# |X |X |X | |Decrease selected slider/numberMove selected point along path/curve
 
@@ -188,6 +204,8 @@ View] 2
 |= |[.kcode]#Ctrl# + [.kcode]#=# |X |X |X | |Zoom in
 
 |= |[.kcode]#Alt# + [.kcode]#=# |X |X |X | |⊕ (xor)
+
+| = |[.kcode]#Alt# + [.kcode]#Shift# + [.kcode]#=#  |X |X | X| X| ⊕ (xor)
 
 |< |[.kcode]#Alt# + [.kcode]#<# |X | |X |[.kcode]#Alt# + [.kcode]#<# |less-than-or-equal-to ≤
 
@@ -307,7 +325,9 @@ Spreadsheet: go to the next row with input below
 |PgDn↓ |[.kcode]#⇟# |X |X | | |Go to last item in image:16px-Menu_view_construction_protocol.svg.png[Menu view
 construction protocol.svg,width=16,height=16] xref:/Construction_Protocol.adoc[construction protocol] (only Desktop) *3D
 Graphics* Decrease z-coordinate of selected point
+
 |===
 
-In addition, use [.kcode]#Alt# + [.kcode]#Shift# (Mac OS X [.kcode]#Ctrl# + [.kcode]#Shift#) to get upper-case Greek
+In addition, use [.kcode]#Alt# + [.kcode]#Shift# (MacOS: [.kcode]#Option# + [.kcode]#Shift#) to get upper-case Greek
 characters.
+


### PR DESCRIPTION
Add shortcuts in the corresponding rows
<Alt><Shift>2 €
<Alt><Shift>3 «
<Alt><Shift>4 »
<Alt><Shift>5 £
<Alt><Shift>7 \
<Alt><Shift>8 ⊗
<Alt><Shift>9 {
<Alt><Shift>0 }
<Alt><Shift>= ⊕