### PR TITLE
Update Polyline.adoc

### DIFF
--- a/en/modules/ROOT/pages/commands/Polyline.adoc
+++ b/en/modules/ROOT/pages/commands/Polyline.adoc
@@ -21,20 +21,17 @@ Polyline( <Point>, ..., <Point> )::
 [NOTE]
 ====
 
-*Notes:*
-
 * The polygonal chain length is displayed in the image:16px-Menu_view_algebra.svg.png[Menu view
 algebra.svg,width=16,height=16] xref:/Algebra_View.adoc[Algebra View].
 * It is also possible to create a discontinuous polygonal:
 
+====
 [EXAMPLE]
 ====
 
 `++Polyline((1, 3), (4, 3), (?,?), (6, 2), (4, -2), (2, -2))++` yields the value _9.47_ in
 image:16px-Menu_view_algebra.svg.png[Menu view algebra.svg,width=16,height=16] _Algebra View_, and the corresponding
 polygonal in image:16px-Menu_view_graphics.svg.png[Menu view graphics.svg,width=16,height=16] _Graphics View_.
-
-====
 
 ====
 


### PR DESCRIPTION
The example of the NOTE is described within the EXAMPLE, but due to the specifications of ASCIIDOC, it results in unintended output. Therefore, the content of the NOTE and the EXAMPLE have been separated.