### PR TITLE
Update Element.adoc

### DIFF
--- a/en/modules/ROOT/pages/commands/Element.adoc
+++ b/en/modules/ROOT/pages/commands/Element.adoc
@@ -8,7 +8,7 @@ Element( <List>, <Position of Element n> )::
 [EXAMPLE]
 ====
 
-`++Element({1, 3, 2}, 2)++` yields _3_, the second element of _\{1, 3, 2}_.
+`++Element({1, 3, 2}, 2)++` yields _3_, the second element of _{1, 3, 2}_.
 
 ====
 
@@ -18,14 +18,15 @@ Element( <List>, <Position of Element n> )::
 In the image:16px-Menu_view_cas.svg.png[Menu view cas.svg,width=16,height=16] xref:/CAS_View.adoc[CAS View] undefined
 variables can be used as well.
 
+====
+
 [EXAMPLE]
 ====
 
-`++Element({a, b, c}, 2)++` yields _b_, the second element of _\{a, b, c}_.
+`++Element({a, b, c}, 2)++` yields _b_, the second element of _{a, b, c}_.
 
 ====
 
-====
 
 Element( <Matrix>, <Row>, <Column> )::
   Yields the element of the matrix in the given row and column.
@@ -44,6 +45,8 @@ stem:[\begin{pmatrix}1&3&2\\0&3&-2\end{pmatrix}].
 In the image:16px-Menu_view_cas.svg.png[Menu view cas.svg,width=16,height=16] xref:/CAS_View.adoc[CAS View] undefined
 variables can be used as well.
 
+====
+
 [EXAMPLE]
 ====
 
@@ -52,7 +55,7 @@ stem:[\begin{pmatrix}a&b&c\\d&e&f\end{pmatrix}].
 
 ====
 
-====
+
 
 Element( <List>, <Index1>, <Index2>, ...)::
   Provided list is _n_-dimensional list, one can specify up to _n_ indices to obtain an element (or list of elements) at
@@ -61,9 +64,9 @@ Element( <List>, <Index1>, <Index2>, ...)::
 [EXAMPLE]
 ====
 
-Let _L = \{\{\{1, 2}, \{3, 4}}, \{\{5, 6}, \{7, 8}}}_.
+Let _L = {{{1, 2}, {3, 4}}, {{5, 6}, {7, 8}}}_.
 
-Then `++Element(L, 1, 2, 1)++` yields _3_, `++Element(L, 2, 2)++` yields _\{7, 8}_.
+Then `++Element(L, 1, 2, 1)++` yields _3_, `++Element(L, 2, 2)++` yields _{7, 8}_.
 
 ====
 


### PR DESCRIPTION
The EXAMPLE is within the NOTE, but due to the specifications of ASCIIDOC, it results in unintended display. Therefore, the NOTE and the EXAMPLE have been separated.