### PR TITLE
Update Join.adoc

### DIFF
--- a/en/modules/ROOT/pages/commands/Join.adoc
+++ b/en/modules/ROOT/pages/commands/Join.adoc
@@ -8,7 +8,7 @@ Join( <List>, <List>, ... )::
 [EXAMPLE]
 ====
 
-`++Join({5, 4, 3}, {1, 2, 3})++` creates the list _\{5, 4, 3, 1, 2, 3}_.
+`++Join({5, 4, 3}, {1, 2, 3})++` creates the list _{5, 4, 3, 1, 2, 3}_.
 
 ====
 
@@ -26,10 +26,8 @@ Join( <List of Lists> )::
 [EXAMPLE]
 ====
 
-*Examples:*
-
-* `++Join({{1, 2}})++` creates the list _\{1, 2}_.
-* `++Join({{1, 2, 3}, {3, 4}, {8, 7}})++` creates the list _\{1, 2, 3, 3, 4, 8, 7}_.
+* `++Join({{1, 2}})++` creates the list _{1, 2}_.
+* `++Join({{1, 2, 3}, {3, 4}, {8, 7}})++` creates the list _{1, 2, 3, 3, 4, 8, 7}_.
 
 ====
 


### PR DESCRIPTION
Remove the backslashes before the curly brackets and eliminate duplication of “Examples”.