### PR TITLE
Update RandomElement.adoc

### DIFF
--- a/en/modules/ROOT/pages/commands/RandomElement.adoc
+++ b/en/modules/ROOT/pages/commands/RandomElement.adoc
@@ -9,7 +9,7 @@ RandomElement( <List> )::
 [EXAMPLE]
 ====
 
-`++RandomElement({3, 2, -4, 7})++` yields one of _\{-4, 2, 3, 7}_.
+`++RandomElement({3, 2, -4, 7})++` yields one of _{-4, 2, 3, 7}_.
 
 ====
 
@@ -19,14 +19,16 @@ RandomElement( <List> )::
 *image:18px-Bulbgraph.png[Note,title="Note",width=18,height=22] Hint:* In the image:16px-Menu_view_cas.svg.png[Menu view
 cas.svg,width=16,height=16] xref:/CAS_View.adoc[CAS View] this command also works with symbolic input.
 
+====
+
 [EXAMPLE]
 ====
 
-`++RandomElement({a,b,c,d})++` yields one of _\{a, b, c, d}_.
+`++RandomElement({a,b,c,d})++` yields one of _{a, b, c, d}_.
 
 ====
 
-====
+
 
 [NOTE]
 ====


### PR DESCRIPTION
The EXAMPLE is within the NOTE, but due to the specifications of ASCIIDOC, it results in unintended display. Therefore, the NOTE and the EXAMPLE have been separated and remove the backslashes before the curly brackets.