### PR TITLE
Update BinomialCoefficient.adoc

### DIFF
--- a/en/modules/ROOT/pages/commands/BinomialCoefficient.adoc
+++ b/en/modules/ROOT/pages/commands/BinomialCoefficient.adoc
@@ -20,6 +20,8 @@ BinomialCoefficient( <Number>, <Number> )::
 image:16px-Menu_view_cas.svg.png[Menu view cas.svg,width=16,height=16] xref:/CAS_View.adoc[CAS View] contains undefined
 variables, then this command yields a formula for the binomial coefficient.
 
+====
+
 [EXAMPLE]
 ====
 
@@ -27,7 +29,6 @@ variables, then this command yields a formula for the binomial coefficient.
 
 ====
 
-====
 
 [NOTE]
 ====


### PR DESCRIPTION
The EXAMPLE is within the NOTE, but due to the specifications of ASCIIDOC, it results in unintended display. Therefore, the NOTE and the EXAMPLE have been separated.