### PR TITLE
Update Percentile.adoc

### DIFF
--- a/en/modules/ROOT/pages/commands/Percentile.adoc
+++ b/en/modules/ROOT/pages/commands/Percentile.adoc
@@ -20,6 +20,8 @@ Percentile( <List of Numbers>, <Percent> )::
 The commands xref:/commands/Q1.adoc[Quartile] and Percentile use different rules and do not always return matching
 results.
 
+====
+
 [EXAMPLE]
 ====
 
@@ -27,4 +29,3 @@ results.
 
 ====
 
-====


### PR DESCRIPTION
The EXAMPLE is within the NOTE, but due to the specifications of ASCIIDOC, it results in unintended display. Therefore, the NOTE and the EXAMPLE have been separated.