### PR TITLE
Update Sample.adoc

### DIFF
--- a/en/modules/ROOT/pages/commands/Sample.adoc
+++ b/en/modules/ROOT/pages/commands/Sample.adoc
@@ -8,7 +8,7 @@ Sample( <List>, <Size> )::
 [EXAMPLE]
 ====
 
-`++Sample({1, 2, 3, 4, 5}, 5)++` yields for example _list1 = \{1, 2, 1, 5, 4}_.
+`++Sample({1, 2, 3, 4, 5}, 5)++` yields for example _list1 = {1, 2, 1, 5, 4}_.
 
 ====
 
@@ -19,7 +19,7 @@ Sample( <List>, <Size>, <With Replacement> )::
 [EXAMPLE]
 ====
 
-`++Sample({1, 2, 3, 4, 5}, 5, true)++` yields for example _list1 = \{2, 3, 3, 4, 5}_.
+`++Sample({1, 2, 3, 4, 5}, 5, true)++` yields for example _list1 = {2, 3, 3, 4, 5}_.
 
 ====
 
@@ -29,15 +29,14 @@ Sample( <List>, <Size>, <With Replacement> )::
 *image:18px-Bulbgraph.png[Note,title="Note",width=18,height=22] Hint:* In the image:16px-Menu_view_cas.svg.png[Menu view
 cas.svg,width=16,height=16] xref:/CAS_View.adoc[CAS View] the input list can contain different types of objects:
 
+====
+
 [EXAMPLE]
 ====
 
-*Examples:*
 
-* `++Sample({-5, 2, a, 7, c}, 3)++` yields for example _\{a, 7, -5}_.
-* The list can include lists as well: Let _List1_ be _\{1, 2, 3}_: `++Sample({List1, 4, 5, 6, 7, 8}, 3, false)++` yields
-for example _\{6, \{1, 2, 3}, 4}_.
-
-====
+* `++Sample({-5, 2, a, 7, c}, 3)++` yields for example _{a, 7, -5}_.
+* The list can include lists as well: Let _List1_ be _{1, 2, 3}_: `++Sample({List1, 4, 5, 6, 7, 8}, 3, false)++` yields
+for example _{6, {1, 2, 3}, 4}_.
 
 ====


### PR DESCRIPTION
Remove the backslashes before the curly brackets.
The EXAMPLE is within the NOTE, but due to the specifications of ASCIIDOC, it results in unintended display. Therefore, the NOTE and the EXAMPLE have been separated.