### PR TITLE
Update SampleSD.adoc

### DIFF
--- a/en/modules/ROOT/pages/commands/SampleSD.adoc
+++ b/en/modules/ROOT/pages/commands/SampleSD.adoc
@@ -38,6 +38,8 @@ SampleSD( <List of Numbers>, <List of Frequencies> )::
 image:16px-Menu_view_cas.svg.png[Menu view cas.svg,width=16,height=16] xref:/CAS_View.adoc[CAS View], the command yields
 a formula for the _sample standard deviation_.
 
+====
+
 [EXAMPLE]
 ====
 
@@ -45,4 +47,3 @@ a formula for the _sample standard deviation_.
 
 ====
 
-====


### PR DESCRIPTION
The EXAMPLE is within the NOTE, but due to the specifications of ASCIIDOC, it results in unintended display. Therefore, the NOTE and the EXAMPLE have been separated.