### PR TITLE
Update SampleVariance.adoc

### DIFF
--- a/en/modules/ROOT/pages/commands/SampleVariance.adoc
+++ b/en/modules/ROOT/pages/commands/SampleVariance.adoc
@@ -31,12 +31,12 @@ SampleVariance( <List of Numbers>, <List of Frequencies> )::
 image:16px-Menu_view_spreadsheet.svg.png[Menu view spreadsheet.svg,width=16,height=16] xref:/CAS_View.adoc[CAS View]
 contains undefined variables, this command yields a formula for the sample variance.
 
+====
+
 [EXAMPLE]
 ====
 
 `++SampleVariance({a, b, c})++` yields stem:[\frac{1}\{3} a^\{2} - \frac{1}\{3} ab - \frac{1}\{3}ac + \frac{1}\{3}
 b^\{2} - \frac{1}\{3} bc + \frac{1}\{3} c^\{2}].
-
-====
 
 ====


### PR DESCRIPTION
The EXAMPLE is within the NOTE, but due to the specifications of ASCIIDOC, it results in unintended display. Therefore, the NOTE and the EXAMPLE have been separated.