### PR TITLE
Update Payment.adoc

### DIFF
--- a/en/modules/ROOT/pages/commands/Payment.adoc
+++ b/en/modules/ROOT/pages/commands/Payment.adoc
@@ -17,6 +17,7 @@ the end of the period. If you enter 1 it is due at the beginning of the period.
 ====
 
 `++Payment(6%/12, 10, 10000, 0,1)++` yields a monthly payment for a loan of -1022.59.
+====
 
 [NOTE]
 ====
@@ -27,7 +28,7 @@ payments.
 
 ====
 
-====
+
 
 [NOTE]
 ====


### PR DESCRIPTION
The example of the NOTE is described within the EXAMPLE, but due to the specifications of ASCIIDOC, it results in unintended output. Therefore, the content of the NOTE and the EXAMPLE have been separated.