### PR TITLE
Update PresentValue.adoc

### DIFF
--- a/en/modules/ROOT/pages/commands/PresentValue.adoc
+++ b/en/modules/ROOT/pages/commands/PresentValue.adoc
@@ -20,14 +20,13 @@ the end of the period. If you enter 1 it is due at the beginning of the period.
 
 `++PresentValue(12%/12, 4*12, -100, 5000, 1)++` yields a present value of 734.07.
 
+====
 [NOTE]
 ====
 
 Make sure that you are consistent about the units you use for `++<Rate>++` and `++<Number of Periods>++`. If you make
 monthly payments on a four-year loan at an annual interest rate of 12 percent, use 12%/12 for rate and 4*12 for number
 of payments.
-
-====
 
 ====
 


### PR DESCRIPTION
The example of the NOTE is described within the EXAMPLE, but due to the specifications of ASCIIDOC, it results in unintended output. Therefore, the content of the NOTE and the EXAMPLE have been separated.