### PR TITLE
Update SurdText.adoc

### DIFF
--- a/en/modules/ROOT/pages/commands/SurdText.adoc
+++ b/en/modules/ROOT/pages/commands/SurdText.adoc
@@ -8,8 +8,6 @@ SurdText( <Number> )::
 [EXAMPLE]
 ====
 
-*Examples:*
-
 * `++SurdText(2.414213562373095)++` creates _stem:[1 + \sqrt{2}]_
 * `++SurdText(2.439230484541326)++` creates _stem:[\frac{7+3 \sqrt{3} }\{5}]_
 
@@ -21,8 +19,6 @@ SurdText( <Number>, <List> )::
 
 [EXAMPLE]
 ====
-
-*Examples:*
 
 * `++SurdText(3.718281828459045, {exp(1)})++` creates _stem:[e + 1]_
 * `++SurdText(5.382332347441762, {sqrt(2), sqrt(3), sqrt(5)})++` creates _stem:[ \sqrt{5} + \sqrt{3} + \sqrt{2}]_
@@ -43,20 +39,14 @@ SurdText( <Point> )::
 [NOTE]
 ====
 
-*Notes:*
-
 * In order to use this command in a Text object, the option *_LaTeX Formula_* needs to be enabled in the _Text_ tab of
 the image:16px-Menu-options.svg.png[Menu-options.svg,width=16,height=16] xref:/Properties_Dialog.adoc[Properties Dialog]
 of the text.
 * Since this command works with a rounded decimal number as input, sometimes the result will be unexpected.
 * If a suitable answer can't be found, the number will be returned.
 
-[EXAMPLE]
-====
-
+*Example:*
 `++SurdText(1.23456789012345)++` returns _1.23456789012345_.
-
-====
 
 * See also the xref:/commands/FractionText.adoc[FractionText] and xref:/commands/ScientificText.adoc[ScientificText]
 commands.


### PR DESCRIPTION
There was an ‘example’ in the ‘Note’, but separating it as usual would make the content strange, so I left the ‘example’ in the ‘Note’ and made it bold.