### PR TITLE
Update Invert.adoc

### DIFF
--- a/en/modules/ROOT/pages/commands/Invert.adoc
+++ b/en/modules/ROOT/pages/commands/Invert.adoc
@@ -45,6 +45,8 @@ Invert( <Function> )::
 The function must contain just one _x_ and no account is taken of domain or range, for example for f(x) = x^2 or f(x) =
 sin(x). If there is more than one _x_ in the function another command might help you:
 
+====
+
 [EXAMPLE]
 ====
 
@@ -53,7 +55,7 @@ functions.
 
 ====
 
-====
+
 
 [NOTE]
 ====


### PR DESCRIPTION
The EXAMPLE is within the NOTE, but due to the specifications of ASCIIDOC, it results in unintended display. Therefore, the NOTE and the EXAMPLE have been separated.