### PR TITLE
Update MatrixRank.adoc

### DIFF
--- a/en/modules/ROOT/pages/commands/MatrixRank.adoc
+++ b/en/modules/ROOT/pages/commands/MatrixRank.adoc
@@ -8,8 +8,6 @@ MatrixRank( <Matrix> )::
 [EXAMPLE]
 ====
 
-*Examples:*
-
 * `++MatrixRank({{2, 2}, {1, 1}})++` yields _1_.
 * `++MatrixRank({{1, 2}, {3, 4}})++` yields _2_.
 * Let `++A = {{1, 2, 3}, {1, 1, 1}, {2, 2, 2}}++` be a 3x3-matrix. `++MatrixRank(A)++` yields _2_.
@@ -22,11 +20,11 @@ MatrixRank( <Matrix> )::
 *image:18px-Bulbgraph.png[Note,title="Note",width=18,height=22] Hint:* In the image:16px-Menu_view_cas.svg.png[Menu view
 cas.svg,width=16,height=16] xref:/CAS_View.adoc[CAS View] this command also works with undefined variables.
 
+====
+
 [EXAMPLE]
 ====
 
 `++MatrixRank({{1, 2}, {k*1,  k*2}})++` yields _1_.
-
-====
 
 ====


### PR DESCRIPTION
The EXAMPLE is within the NOTE, but due to the specifications of ASCIIDOC, it results in unintended display. Therefore, the NOTE and the EXAMPLE have been separated.