### PR TITLE
Update ReducedRowEchelonForm.adoc

### DIFF
--- a/en/modules/ROOT/pages/commands/ReducedRowEchelonForm.adoc
+++ b/en/modules/ROOT/pages/commands/ReducedRowEchelonForm.adoc
@@ -30,6 +30,6 @@ ReducedRowEchelonForm( <Matrix> )::
 * `++ReducedRowEchelonForm({{1, 6, 4}, {2, 8, 9}, {4, 5, 6}})++` yields the matrix stem:[ \begin{pmatrix} 1 & 0 & 0 \\
 0 & 1 & 0 \\ 0 & 0 & 1 \end{pmatrix}].
 * `++ReducedRowEchelonForm({{2, 10, 11, 4}, {2, (-5), (-6), 12}, {2, 5, 3, 2}})++` yields the matrix stem:[
-\begin{pmatrix} 1 & 0 & 0 & 5\\ 0 & 1 & 0 & \frac{-14}\{5} \\ 0 & 0 & 1 & 2\end{pmatrix}].
+\begin{pmatrix} 1 & 0 & 0 & 5\\ 0 & 1 & 0 & \frac{-14}{5} \\ 0 & 0 & 1 & 2\end{pmatrix}].
 
 ====


### PR DESCRIPTION
In the Japanese version, after changing (\frac{-14}{5}) to (\frac{-14}{5}), it displayed correctly. Is this the difference between what can and cannot be displayed in LaTeX?