### PR TITLE
Update Numeric.adoc

### DIFF
--- a/en/modules/ROOT/pages/commands/Numeric.adoc
+++ b/en/modules/ROOT/pages/commands/Numeric.adoc
@@ -31,6 +31,8 @@ Numeric( <Expression>, <Significant Figures> )::
 If you don't specify enough digits then you can get an apparently wrong answer due to
 http://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html[floating point cancelation].
 
+====
+
 [EXAMPLE]
 ====
 
@@ -39,7 +41,6 @@ give _4096_ but
 `++Numeric(-500000000/785398163*sin(785398163/500000000)*1258025227.19^2+500000000/785398163*1258025227.19^2,30)++` will
 give _0.318309886345536696694580314215_.
 
-====
 
 ====
 


### PR DESCRIPTION
The EXAMPLE is within the NOTE, but due to the specifications of ASCIIDOC, it results in unintended display. Therefore, the NOTE and the EXAMPLE have been separated.