### PR TITLE
Update UnitVector.adoc

### DIFF
--- a/en/modules/ROOT/pages/commands/UnitVector.adoc
+++ b/en/modules/ROOT/pages/commands/UnitVector.adoc
@@ -43,14 +43,12 @@ Let `++s = Segment((1,1),(4,5))++`.
 cas.svg,width=16,height=16] xref:/CAS_View.adoc[CAS View] three-dimensional vectors and vectors with undefined variables
 are also valid inputs.
 
+====
+
 [EXAMPLE]
 ====
 
-*Examples:*
-
 * `++UnitVector((a, b))++` yields _(stem:[\frac{a}{\sqrt{a a + b b}}], stem:[\frac{b}{\sqrt{a a + b b}}])_.
 * `++UnitVector((2, 4, 4))++` yields _(stem:[\frac{1}{3}], stem:[\frac{2}{3}], stem:[\frac{2}{3}])_.
-
-====
 
 ====


### PR DESCRIPTION
The EXAMPLE is within the NOTE, but due to the specifications of ASCIIDOC, it results in unintended display. Therefore, the NOTE and the EXAMPLE have been separated.