### PR TITLE
Update NIntegral.adoc

### DIFF
--- a/en/modules/ROOT/pages/commands/NIntegral.adoc
+++ b/en/modules/ROOT/pages/commands/NIntegral.adoc
@@ -35,11 +35,11 @@ NIntegral( <Function>, <Variable>, <Start Value>, <End Value> )::
   Computes (numerically) the definite integral stem:[\int_a^bf(t)\mathrm{d}x] of the given function _f_, from _a_
   (_Start value_) to _b_ (_End value_), with respect to the given variable.
 
+====
+
 [EXAMPLE]
 ====
 
 `++NIntegral(ℯ^(-a^2), a, 0, 1)++` yields _0.75_.
-
-====
 
 ====


### PR DESCRIPTION
The EXAMPLE is within the NOTE, but due to the specifications of ASCIIDOC, it results in unintended display. Therefore, the NOTE and the EXAMPLE have been separated.