### PR TITLE
Update Angle.adoc

### DIFF
--- a/en/modules/ROOT/pages/commands/Angle.adoc
+++ b/en/modules/ROOT/pages/commands/Angle.adoc
@@ -88,9 +88,9 @@ _radians_.
 
 and in _CAS View_ :
 
-* `++Angle(x + 2,  2x + 3)++` yields stem:[acos \left( 3 \cdot \frac{\sqrt{10}}\{10} \right)].
+* `++Angle(x + 2,  2x + 3)++` yields stem:[acos \left( 3 \cdot \frac{\sqrt{10}}{10} \right)].
 * Define `++f(x) := x + 2++` and `++g(x) := 2x + 3++` then command `++Angle(f(x), g(x))++` yields stem:[acos \left(3
-\cdot \frac{\sqrt{10}}\{10} \right)].
+\cdot \frac{\sqrt{10}}{10} \right)].
 
 ====
 


### PR DESCRIPTION
Correct some LaTeX syntax.
This command cannot be used in the web version of GeoGebra. In the desktop version, arccosine is displayed as cos^{-1}, but the previous notation has been retained.