### PR TITLE
Update Action_Object_Tools.adoc

### DIFF
--- a/en/modules/ROOT/pages/tools/Action_Object_Tools.adoc
+++ b/en/modules/ROOT/pages/tools/Action_Object_Tools.adoc
@@ -4,9 +4,11 @@ ifdef::env-github[:imagesdir: /en/modules/ROOT/assets/images]
 
 These xref:/Tools.adoc[tools] allow you to create xref:/Action_Objects.adoc[Action Objects]. They are by default grouped
 under image:Tool_Slider.gif[Tool Slider.gif,width=32,height=32] icon (the second from the right in the _Graphics View
-Toolbar_) in the xref:/Toolbar.adoc[toolbar]. Currently there are four action object tools:
+Toolbar_) in the xref:/Toolbar.adoc[toolbar]. Currently there are six action object tools:
 
+* xref:/tools/Slider.adoc[Slider Tool]
+* xref:/tools/Text.adoc[Text Tool]
+* xref:/tools/Image.adoc[Image Tool]
 * xref:/tools/Button.adoc[Button Tool]
 * xref:/tools/Check_Box.adoc[Check Box Tool]
 * xref:/tools/Input_Box.adoc[Input Box Tool]
-* xref:/tools/Slider.adoc[Slider Tool]


### PR DESCRIPTION
I don't think the text tool and image tool are action object tools, but I included them because they are in the second toolbox from the right. The name "action object tools" might not be appropriate.