### PR TITLE
Update Probability_Calculator.adoc

### DIFF
--- a/en/modules/ROOT/pages/Probability_Calculator.adoc
+++ b/en/modules/ROOT/pages/Probability_Calculator.adoc
@@ -43,7 +43,7 @@ image:Export16.png[Export16.png,width=16,height=16] export the graph.
 
 You may export your distribution as a picture file (.png), copy it to your computer's clipboard (GeoGebra Desktop) or
 copy it to the image:16px-Menu_view_graphics.svg.png[Menu view graphics.svg,width=16,height=16]
-xref:/Graphics_View.adoc[Graphics View] (GeoGebra Desktop).
+xref:/Graphics_View.adoc[Graphics View].
 
 ====
 


### PR DESCRIPTION
We can copy the distribution to the Graphics View from the Probability Calculator Style Bar in the web version of GeoGebra Classic.