### PR TITLE
Update Solve.adoc

### DIFF
--- a/en/modules/ROOT/pages/commands/Solve.adoc
+++ b/en/modules/ROOT/pages/commands/Solve.adoc
@@ -54,7 +54,7 @@ Solve( <List of Equations>, <List of Variables> )::
 [EXAMPLE]
 ====
 
-* `++Solve({x = 4 x + y , y + x = 2}, {x, y})++` yields _( x = -1, y = 3 )_
+* `++Solve({x = 4 x + y , y + x = 2}, {x, y})++` yields _{ x = -1, y = 3 }_
 * `++Solve({2a^2 + 5a + 3 = b, a + b = 3}, {a, b})++` yields _{{a = 0, b = 3}, {a = -3, b = 6}}_.
 
 ====

--- a/en/modules/ROOT/pages/commands/Solve.adoc
+++ b/en/modules/ROOT/pages/commands/Solve.adoc
@@ -54,7 +54,7 @@ Solve( <List of Equations>, <List of Variables> )::
 [EXAMPLE]
 ====
 
-* `++Solve({x = 4 x + y , y + x = 2}, {x, y})++` yields _{ x = -1, y = 3 }_
+* `++Solve({x = 4 x + y , y + x = 2}, {x, y})++` yields _{{ x = -1, y = 3 }}_
 * `++Solve({2a^2 + 5a + 3 = b, a + b = 3}, {a, b})++` yields _{{a = 0, b = 3}, {a = -3, b = 6}}_.
 
 ====


### PR DESCRIPTION
In line 57, where there is an example whose solution is the ordered pair (-1,3), it said '_( x = -1, y = 3 )_' and it should say '_{ x = -1, y = 3 }_'. That is, I fixed the parentheses and replaced them with braces.