### PR TITLE
Update LaTeX.adoc

### DIFF
--- a/en/modules/ROOT/pages/LaTeX.adoc
+++ b/en/modules/ROOT/pages/LaTeX.adoc
@@ -9,7 +9,7 @@ in LaTeX syntax.
 [NOTE]
 ====
 
-In order to create text that contains a LaTeX formula as well as text you may enter the text inside \text\{}, while
+In order to create text that contains a LaTeX formula as well as text you may enter the text inside \text{}, while
 _LaTex Formula_ is activated.
 
 ====


### PR DESCRIPTION
In line 12, there was an extra brace '{' in the \text{} command; it should say '\text{}' and it was written as '\text\{}'.