### PR TITLE
Update Help_Menu.adoc

### DIFF
--- a/en/modules/ROOT/pages/Help_Menu.adoc
+++ b/en/modules/ROOT/pages/Help_Menu.adoc
@@ -12,7 +12,7 @@ http://wiki.geogebra.org/en/Tutorials[GeoGebra Tutorials] to work offline.
 
 == Tutorials
 
-This menu item opens the /s_index_php?title=Tutorial:Main_Page&action=edit&redlink=1.adoc[tutorial part] of GeoGebraWiki
+This menu item opens the https://www.geogebra.org/m/XUv5mXTm[tutorial part] of GeoGebra Wiki
 in your browser.
 
 == image:24px-Menu-help.svg.png[Menu-help.svg,width=24,height=24] Help


### PR DESCRIPTION
The link to the tutorials is incorrect; I wrote the link that I thought it should be, please check if it is correct so I can also fix it in the Spanish version. In the same paragraph, it said "GeoGebraWiki" as one word, and I added a space that seemed correct to me.