### PR TITLE
Update Help_Menu.adoc

### DIFF
--- a/en/modules/ROOT/pages/Help_Menu.adoc
+++ b/en/modules/ROOT/pages/Help_Menu.adoc
@@ -6,7 +6,7 @@ ifdef::env-github[:imagesdir: /en/modules/ROOT/assets/images]
 ====
 
 Following four menu items work only provided you have access to the internet. You can download the
-http://wiki.geogebra.org/en/Tutorials[GeoGebra Tutorials] to work offline.
+https://www.geogebra.org/m/XUv5mXTm[GeoGebra Tutorials] to work offline.
 
 ====
 
@@ -15,14 +15,13 @@ http://wiki.geogebra.org/en/Tutorials[GeoGebra Tutorials] to work offline.
 This menu item opens the https://www.geogebra.org/m/XUv5mXTm[tutorial part] of GeoGebra Wiki
 in your browser.
 
-== image:24px-Menu-help.svg.png[Menu-help.svg,width=24,height=24] Help
+== Manual
 
 This menu item opens the online xref:index.adoc[GeoGebra Manual] in your browser.
 
-== GeoGebra Forum
+== image:24px-Menu-help.svg.png[Menu-help.svg,width=24,height=24] Help
 
-This menu item opens the http://help.geogebra.org/[GeoGebra User Forum] in your default web browser. You can post and
-answer GeoGebra-related questions and problems in the GeoGebra User Forum.
+This menu item opens the online https://help.geogebra.org/hc/en-us[Help Center] in your browser.
 
 == Report Bug
 

--- a/en/modules/ROOT/pages/Help_Menu.adoc
+++ b/en/modules/ROOT/pages/Help_Menu.adoc
@@ -12,7 +12,7 @@ http://wiki.geogebra.org/en/Tutorials[GeoGebra Tutorials] to work offline.
 
 == Tutorials
 
-This menu item opens the /s_index_php?title=Tutorial:Main_Page&action=edit&redlink=1.adoc[tutorial part] of GeoGebraWiki
+This menu item opens the https://www.geogebra.org/m/XUv5mXTm[tutorial part] of GeoGebra Wiki
 in your browser.
 
 == image:24px-Menu-help.svg.png[Menu-help.svg,width=24,height=24] Help


### PR DESCRIPTION
* The images are missing in the titles; I couldn’t find them in the folders.
* The note that appears at the beginning was incorrectly linked (with the hyperlink).
* The title "Manual" was missing.
* The Help menu did not lead to the Help Center, but to the manual.
* The GeoGebra forum is no longer in this menu, and I chose to remove it; please check.