### PR TITLE
Update Perspectives_Menu.adoc

### DIFF
--- a/en/modules/ROOT/pages/Perspectives_Menu.adoc
+++ b/en/modules/ROOT/pages/Perspectives_Menu.adoc
@@ -14,7 +14,7 @@ Six different standard _perspectives_ are available:
 |xref:/Algebra_View.adoc[Algebra View] and xref:/Graphics_View.adoc[Graphics View] (with axes) are displayed.
 
 |image:24px-Perspectives_geometry.svg.png[Perspectives geometry.svg,width=24,height=24] |_Geometry_: |Just
-xref:/Graphics_View.adoc[Graphics View] (with grid) is displayed.
+xref:/Graphics_View.adoc[Graphics View] (without grid) is displayed.
 
 |image:24px-Menu_view_spreadsheet.svg.png[Menu view spreadsheet.svg,width=24,height=24] |_Spreadsheet & Graphics_:
 |xref:/Spreadsheet_View.adoc[Spreadsheet View] and xref:/Graphics_View.adoc[Graphics View] are displayed.


### PR DESCRIPTION
The "Geometry" perspective does not display the grid, so I changed "with" to "without" grid. On the other hand, wouldn't it be more appropriate for the perspectives to be ordered as they appear in the software?