### PR TITLE
Update Cone.adoc - correct order of arguments

### DIFF
--- a/en/modules/ROOT/pages/commands/Cone.adoc
+++ b/en/modules/ROOT/pages/commands/Cone.adoc
@@ -6,8 +6,8 @@ Cone( <Circle>, <Height> )::
   Creates a cone with given base and height.
 Cone( <Point>, <Point>, <Radius> )::
   Creates a cone with vertex (second point), circle center (first point) and given radius.
-Cone( <Point>, <Vector>, <Angle α> )::
-  Creates an infinite cone with given point as vertex, axis of symmetry parallel to the given vector and apex angle 2α.
+Cone( <Vector>, <Point>, <Angle α> )::
+  Creates an infinite cone with axis of symmetry parallel to the given vector, given point as vertex, and apex angle 2α.
 
 [NOTE]
 ====


### PR DESCRIPTION
The order of the arguments in the version
```
Cone( <Vector>, <Point>, <Angle> )
```
is, in the current version of the documentation, erroneously given with the vector and the point swapped. This change corrects that.